### PR TITLE
Specified licenses for the 'MCMic levels' and 'Levels by squarescross' levelpacks

### DIFF
--- a/addons05
+++ b/addons05
@@ -64,6 +64,7 @@ https://forum.freegamedev.net/viewtopic.php?f=48&t=2922"
 		file="levelpacks/mcmiclevels.zip"
 		author=MCMic
 		version=1
+		license="CC BY 4.0"
 	}
 	entry("Twelve Pits") {
 		file="levelpacks/Twelve%20Pits.zip"
@@ -77,6 +78,7 @@ https://forum.freegamedev.net/viewtopic.php?f=48&t=2922"
 		file="levelpacks/squarecross_levels.zip"
 		author=squarecross
 		version=1
+		license=CC0
 		website="https://forum.freegamedev.net/viewtopic.php?f=48&t=5351#p54947"
 	}
 	entry("Ákos level pack") {


### PR DESCRIPTION
Heard back from both specifying the license of their levelpacks.